### PR TITLE
typo in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Marketplace",
   "short_description": "Webshop/market on LNbits",
-	"tile": "/market/static/images/bitcoin-shop.png",
-  "lnbits_min_version": "0.11.0",
+  "tile": "/market/static/images/bitcoin-shop.png",
+  "min_lnbits_version": "0.11.0",
   "contributors": ["benarc", "talvasconcelos"]
 }


### PR DESCRIPTION
Fix a typo in config.json `lnbits_min_version` -> `min_lnbits_version`

Also replaced tab with two spaces