### PR TITLE
Added two new shipping zones: Meetup & P2P

### DIFF
--- a/models.json
+++ b/models.json
@@ -1,6 +1,8 @@
 {
   "shipping_zones": [
     "Free (digital)",
+    "Meetup",
+    "P2P",
     "Worldwide",
     "Europe",
     "Australia",

--- a/templates/market/index.html
+++ b/templates/market/index.html
@@ -270,6 +270,8 @@
         shippedModel: false,
         shippingZoneOptions: [
           'Free (digital)',
+          'Meetup',
+          'P2P',
           'Worldwide',
           'Europe',
           'Australia',


### PR DESCRIPTION
**Issue:**
I run my own lnbits server and I got asked several times if its possible to add the shipping zones.

**Doing:** 
Add new shipping zones _Meetup_ and _P2P_.

Looks like this:
![photo_2023-11-13_12-39-30](https://github.com/lnbits/market/assets/106493492/f914dfae-1588-4e4f-9278-18d23f89d177)

Maybe this could be useful for the extension.


cheers 